### PR TITLE
Fix crash during parsing of query string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "harreplayer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harreplayer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A web server that replays HTTP archive (HAR) files",
   "main": "index.js",
   "keywords": [

--- a/src/App/harServerUrl.ts
+++ b/src/App/harServerUrl.ts
@@ -60,7 +60,33 @@ export default class harServerUrl {
     }
 
     private SanitizeUrl(parsedUrl) {
-        this.queryParams = queryString.parse(parsedUrl.query);
+      
+        var query = parsedUrl.query;
+        function parseQuery(query: string): Object {
+          var parsedQuery: Array<string | string> = [];
+          var params: string[] = query.split('&');
+          for (var i=0; i<params.length; i++) {
+            var param: string = params[i];
+            var keyValue: string[] = param.split('=');
+            var key = keyValue[0];
+            var value = keyValue[1];
+            if (!parsedQuery[key]) {
+              parsedQuery[key] = value;
+            }
+            else {
+              parsedQuery[key] += ',' + value;
+            }
+          }
+      
+          return parsedQuery;
+        }
+
+        try {
+            this.queryParams = queryString.parse(parsedUrl.query);        
+        }
+        catch { // backup method that won't throw 'malformed URI' exception
+            this.queryParams = parseQuery(parsedUrl.query);
+        }
 
         var queryParamsToIgnore = this.config.QueryParamsToIgnore.split(',');
         queryParamsToIgnore.push('harfileid');


### PR DESCRIPTION
Fixed bug by adding backup method to parse query string if library method fails